### PR TITLE
Bug 1095868 v2 clickable progress dots

### DIFF
--- a/0-donation-forms/EOY-donation-form-sequential/below-form-content.html
+++ b/0-donation-forms/EOY-donation-form-sequential/below-form-content.html
@@ -69,14 +69,10 @@ var
 
   // Clickable progress dot
   $(".progress").on("click", "li", function() {
-    var dotSelected = $(this).data("position").replace("#page-","");
-    var currentPage = $(".progress li.active").data("position").replace("#page-","");
-    if ( dotSelected < currentPage ) {
-      window.history.go(dotSelected-currentPage);
-      if ( dotSelected-currentPage == -2 ) {
-        hidePage('#page-3', 'incomplete');
-      }
-      window.history.go(dotSelected-currentPage);
+    var pageToGo = $(this).data("position").replace("#page-","");
+    var currPageNum = $(".progress li.active").data("position").replace("#page-","");
+    if ( pageToGo < currPageNum ) {
+      goToPage(currPageNum, pageToGo);
     }
   });
 
@@ -278,6 +274,12 @@ $theForm.find("[name='donation_amount_other']").keyup(updateDonateButtonText);
     $(".progress li.active").prevAll("li").css({ cursor: "pointer" });
   }
 
+  function goToPage(currPageNum, pageNumToGo, validateCurr) {
+    history.pushState({hash: '#page-' + pageNumToGo, page: pageNumToGo}, '', '#page-' + pageNumToGo);
+    hidePage('#page-' + currPageNum, 'complete');
+    showPage('#page-' + pageNumToGo);
+  }
+
   $theForm.on('click', '[data-button-type="next"]', function (e) {
     e.preventDefault();
     $('#one-line-error').hide();
@@ -288,12 +290,9 @@ $theForm.find("[name='donation_amount_other']").keyup(updateDonateButtonText);
 
     var
         $context = $(this),
-        current = $context.data('page'),
-        next = current + 1;
+        current = $context.data('page');
     if ($theForm.parsley().isValid('page-' + current)) {
-      history.pushState({hash: '#page-' + next, page: next}, '', $context.prop('href'));
-      hidePage('#page-' + current, 'complete');
-      showPage('#page-' + next);
+      goToPage(current, current + 1);
     } else {
       $theForm.parsley().validate('page-' + current);
       calculateHeight();
@@ -301,7 +300,6 @@ $theForm.find("[name='donation_amount_other']").keyup(updateDonateButtonText);
   });
 
   win.onpopstate = function (e) {
-
     $('#one-line-error').hide();
     if (e.state.page !== null) {
       hidePage('#page-' + (e.state.page - 1), 'complete');


### PR DESCRIPTION
Here's another way we can make clickable progress dots.  I personally favour our [v1 solution](https://github.com/mozilla/bsd-forms-and-wrappers/pull/16) than this as this has to deal with `pushState` and that alters browser history even more - this seems to make things more complicated.

Either way we'll still have to fix the issues with clickable progress dots + browser back/forward button madness.
