### PR TITLE
Tweak ja locale translation

### DIFF
--- a/0-content-page/EOYFR2014-PayPal-Donate/locales/JPY/locale-ja.json
+++ b/0-content-page/EOYFR2014-PayPal-Donate/locales/JPY/locale-ja.json
@@ -1,13 +1,13 @@
 {
-    "donate_today": "すぐに寄付する",
+    "donate_today": "今すぐ寄付しよう",
     "secure": "セキュリティ対応済",
     "amount": "金額",
     "select_donation": "寄付金額を入力してください",
     "continue": "次に進む",
-    "error_amount": "{{ min_amount }}以上の金額を選択してください。",
-    "donate": "寄付する",
-    "now": "すぐ",
-    "One-time": "一回のみ",
+    "error_amount": "{{ min_amount }} 以上の金額を入力してください。",
+    "donate": "今すぐ",
+    "now": "を寄付",
+    "One-time": "1 回のみ",
     "Monthly": "毎月",
-    "contributions": "寄付金は、501(c)(3) 組織であるモジラ・ファウンデーションへとわたり、モジラが決定する慈善目的に使用されます。その寄付金は米国内において、法律で認められた最大限が課税控除対象となります。"
+    "contributions": "寄付金は、501(c)(3) 組織である Mozilla Foundation へとわたり、Mozilla が決定する慈善目的に使用されます。その寄付金は米国内において、法律で認められた最大限が課税控除対象となります。"
 }


### PR DESCRIPTION
Japanese localizer here. This will
- Update the translation to match the Mozilla style. We don't translate the Mozilla Foundation.
- Fix the label on the **Donate (amount JPY) now** button. The current translation of each word is correct, but the word order is wrong; in Japanese, a verb should usually go after the object.
