### PR TITLE
Make grunt watch grab way fewer files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,8 @@ module.exports = function(grunt) {
     watch: {
       server: {
         files: [
-          '**/*.{html,json}',
+          '0-*/**/*.{html,json}',
+          'Hive*/**/*.{html,json}',
           'Gruntfile.js'
         ],
         tasks: ['bake']


### PR DESCRIPTION
This solves the
`Running "watch" task`
`Waiting...Warning: EMFILE, too many open files`
problem
